### PR TITLE
feat: hedera hashgraph

### DIFF
--- a/common/protob/Makefile
+++ b/common/protob/Makefile
@@ -1,4 +1,4 @@
-check: messages.pb messages-binance.pb messages-bitcoin.pb messages-bootloader.pb messages-cardano.pb messages-common.pb messages-crypto.pb messages-debug.pb messages-ethereum.pb messages-management.pb messages-monero.pb messages-nem.pb messages-ripple.pb messages-stellar.pb messages-tezos.pb messages-eos.pb
+check: messages.pb messages-binance.pb messages-bitcoin.pb messages-bootloader.pb messages-cardano.pb messages-common.pb messages-crypto.pb messages-debug.pb messages-ethereum.pb messages-hedera.proto messages-management.pb messages-monero.pb messages-nem.pb messages-ripple.pb messages-stellar.pb messages-tezos.pb messages-eos.pb
 
 %.pb: %.proto
 	protoc -I/usr/include -I. $< -o $@

--- a/common/protob/messages-hedera.proto
+++ b/common/protob/messages-hedera.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+package hw.trezor.messages.hedera;
+
+message HederaKey {
+    oneof key {
+        bytes ed25519 = 2; // [(nanopb).max_size = 32];
+    }
+}
+
+message HederaId {
+   uint64 shardNum = 1;
+   uint64 realmNum = 2;
+   uint64 tokenNum = 3;
+}
+
+message HederaTimestamp {
+    uint64 seconds = 1;
+    uint32 nanos = 2;
+}
+
+message HederaDuration {
+    uint64 seconds = 1;
+}
+
+message HederaTransactionID {
+    HederaId accountID = 2;
+}
+
+message HederaCryptoCreateTransactionBody {
+    uint64 initialBalance = 2;
+}
+
+message HederaAccountAmount {
+    HederaId accountID = 1;
+    sint64 amount = 2;
+}
+
+message HederaTransferList {
+    repeated HederaAccountAmount accountAmounts = 1; // [(nanopb).max_count = 2];
+}
+
+message HederaTokenTransferList {
+    HederaId token = 1;
+    repeated HederaAccountAmount accountAmounts = 2; // [(nanopb).max_count = 2];
+}
+
+message HederaCryptoTransferTransactionBody {
+    HederaTransferList transfers = 1;
+    repeated HederaTokenTransferList tokenTransfers = 2; // [(nanopb).max_count = 1];
+}
+
+message HederaTokenAssociateBody {
+    HederaId account = 1;
+    repeated HederaId tokens = 2; // [(nanopb).max_count = 1];
+}
+
+message HederaTransactionBody {
+    HederaTransactionID transactionID = 1;
+    uint64 transactionFee = 3;
+    string memo = 6; // [(nanopb).max_size = 100];
+    oneof data {
+        HederaCryptoCreateTransactionBody cryptoCreateAccount = 11;
+        HederaCryptoTransferTransactionBody cryptoTransfer = 14;
+        HederaTokenAssociateBody tokenAssociate = 40;
+    }
+}
+
+/**
+ * Response: Public Key
+ * @end
+ */
+message HederaPublicKey {
+    bytes publicKey = 1;
+}
+
+/**
+ * Request: Ask device for the public key derived from index address_n
+ * @start
+ * @next HederaPublicKey
+ * @next Failure
+ */
+message HederaGetPublicKey {
+    repeated uint32 address_n = 1;  // BIP32 account index (last part of path)
+    bool show_display = 2; // prompt for confirmation on device
+}
+
+/**
+ * Response: Transaction Signature
+ * @end
+ */
+message HederaSignedTx {
+    bytes signature = 1;
+}
+
+/**
+ * Request: Ask Device to sign a tx
+ * @start
+ * @next HederaSignedTx
+ * @next Failure
+ */
+message HederaSignTx {
+    bytes publicKey = 1;
+    HederaTransactionBody tx = 2;
+    uint64 decimals = 3; // you're did it ~ !
+}

--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -193,6 +193,12 @@ enum MessageType {
     MessageType_EthereumTypedDataSignature = 469 [(wire_out) = true];
     MessageType_EthereumSignTypedHash = 470 [(wire_in) = true];
 
+    // Hedera
+    MessageType_HederaGetPublicKey = 804 [(wire_in) = true];
+    MessageType_HederaSignTx = 805 [(wire_in) = true];
+    MessageType_HederaPublicKey = 806 [(wire_out) = true];
+    MessageType_HederaSignedTx = 807 [(wire_out) = true];
+
     // NEM
     MessageType_NEMGetAddress = 67 [(wire_in) = true];
     MessageType_NEMAddress = 68 [(wire_out) = true];

--- a/core/src/apps/hedera/README.md
+++ b/core/src/apps/hedera/README.md
@@ -1,0 +1,15 @@
+# Hedera Hashgraph (Hbar)
+
+MAINTAINER = Chris Campbell <chris@launchbadge.com>
+
+AUTHOR = Chris Campbell <chris@launchbadge.com>
+
+---
+
+## Transactions
+
+This app supports the following transactions:
+
+- Confirm Account (is my key associated with an account)
+- Create Account (create another account and fund it)
+- Send Transfer (send either hbar or a token from you to one party)

--- a/core/src/apps/hedera/__init__.py
+++ b/core/src/apps/hedera/__init__.py
@@ -1,0 +1,5 @@
+from apps.common.paths import PATTERN_BIP44
+
+CURVE = "ed25519"
+SLIP44_ID = 3030
+PATTERN = PATTERN_BIP44

--- a/core/src/apps/hedera/get_pk.py
+++ b/core/src/apps/hedera/get_pk.py
@@ -1,0 +1,22 @@
+from trezor.messages import HederaGetPublicKey
+from trezor.messages import HederaPublicKey
+from trezor.ui.layouts import show_address
+
+from apps.common import paths, seed
+from apps.common.keychain import auto_keychain
+from apps.common.layout import address_n_to_str
+
+
+@auto_keychain(__name__)
+async def get_pk(ctx, msg: HederaGetPublicKey, keychain):
+    await paths.validate_path(ctx, keychain, msg.address_n)
+
+    node = keychain.derive(msg.address_n)
+    pubkey = seed.remove_ed25519_prefix(node.public_key())
+    address = pubkey.hex()
+
+    if msg.show_display:
+        desc = address_n_to_str(msg.address_n)
+        await show_address(ctx, address=address, address_qr=address.upper(), desc=desc)
+
+    return HederaPublicKey(publicKey=pubkey)

--- a/core/src/apps/hedera/layout.py
+++ b/core/src/apps/hedera/layout.py
@@ -1,0 +1,165 @@
+from trezor import ui
+from trezor.messages import ButtonRequestType
+from trezor.messages.HederaAccountAmount import accountID
+from trezor.messages import HederaSignTx
+from trezor.strings import format_amount
+from trezor.ui.components.tt.scroll import Paginated
+from trezor.ui.components.tt.text import Text
+
+from apps.common.confirm import require_confirm, require_hold_to_confirm
+
+
+def format_account(account: accountID) -> str:
+    shard = account.shard
+    realm = account.realm
+    num = account.num
+    return f"{shard}.{realm}.{num}"
+
+
+async def confirm_account(ctx, account_id: str):
+    text = Text("Confirm Account", ui.ICON_CONFIRM, ui.GREEN)
+    text.bold(account_id)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
+
+
+async def confirm_create_account(ctx, initial_balance: str):
+    text = Text("Create Account", ui.ICON_SEND, ui.BLUE)
+    text.normal("Initial Balance:")
+    text.bold(initial_balance)
+    await require_hold_to_confirm(ctx, text, ButtonRequestType.SignTx)
+
+
+async def confirm_transfer_hbar(ctx, msg: HederaSignTx):
+    send_index = 0
+    receive_index = 1
+
+    if msg.tx.cryptoTransfer.transfers.accountAmounts[0].amount > 0:
+        send_index = 1
+        receive_index = 0
+
+    operator = format_account(msg.tx.transactionID.accountID)
+    sender = format_account(msg.tx.cryptoTransfer.transfers.accountAmounts[send_index])
+    receiver = format_account(
+        msg.tx.cryptoTransfer.transfers.accountAmounts[receive_index]
+    )
+    amount = format_amount(
+        msg.tx.cryptoTransfer.transfers.accountAmounts[receive_index].amount, 8
+    )
+    fee = format_amount(msg.tx.fee, 8)
+    memo = msg.tx.memo
+
+    # Summary Page
+    summaryPage = Text("Confirm Transfer", ui.ICON_SEND, ui.BLUE)
+    summaryPage.bold("Asset: Hbar")
+
+    # Operator Page
+    operatorPage = Text("Operator", ui.ICON_SEND, ui.BLUE)
+    operatorPage.bold(operator)
+
+    # Sender
+    senderPage = Text("Sender", ui.ICON_SEND, ui.BLUE)
+    senderPage.bold(sender)
+
+    # Receiver
+    receiverPage = Text("Recipient", ui.ICON_SEND, ui.BLUE)
+    receiverPage.bold(receiver)
+
+    # Amount
+    amountPage = Text("Amount", ui.ICON_SEND, ui.GREEN)
+    amountPage.bold(amount)
+
+    # Fee
+    feePage = Text("Fee", ui.ICON_SEND, ui.BLUE)
+    feePage.bold(fee)
+
+    # Memo
+    memoPage = Text("Memo", ui.ICON_SEND, ui.BLUE)
+    memoPage.normal(memo)
+
+    pages = [
+        summaryPage,
+        operatorPage,
+        senderPage,
+        receiverPage,
+        amountPage,
+        feePage,
+        memoPage,
+    ]
+
+    paginated = Paginated(pages)
+    await require_hold_to_confirm(ctx, paginated, ButtonRequestType.SignTx)
+
+
+async def confirm_transfer_token(ctx, msg: HederaSignTx):
+    send_index = 0
+    receive_index = 1
+
+    if msg.tx.cryptoTransfer.tokenTransfers[0].accountAmounts[0].amount > 0:
+        send_index = 1
+        receive_index = 0
+
+    token = format_account(msg.tx.cryptoTransfer.tokenTransfers[0].token)
+    operator = format_account(msg.tx.transactionID.accountID)
+    sender = format_account(
+        msg.tx.cryptoTransfer.tokenTransfers[0].accountAmounts[send_index].accountID
+    )
+    receiver = format_account(
+        msg.tx.cryptoTransfer.tokenTransfers[0].accountAmounts[receive_index].accountID
+    )
+    amount = format_amount(
+        msg.tx.cryptoTransfer.tokenTransfers[0].accountAmounts[receive_index].amount,
+        msg.decimals,
+    )
+    fee = format_amount(msg.tx.fee, 8)
+    memo = msg.tx.memo
+
+    # Summary Page
+    summaryPage = Text("Confirm Transfer", ui.ICON_SEND, ui.BLUE)
+    summaryPage.bold(f"Asset: {token}")
+
+    # Operator Page
+    operatorPage = Text("Operator", ui.ICON_SEND, ui.BLUE)
+    operatorPage.bold(operator)
+
+    # Sender
+    senderPage = Text("Sender", ui.ICON_SEND, ui.BLUE)
+    senderPage.bold(sender)
+
+    # Receiver
+    receiverPage = Text("Recipient", ui.ICON_SEND, ui.BLUE)
+    receiverPage.bold(receiver)
+
+    # Amount
+    amountPage = Text("Amount", ui.ICON_SEND, ui.GREEN)
+    amountPage.bold(amount)
+
+    # Fee
+    feePage = Text("Fee", ui.ICON_SEND, ui.BLUE)
+    feePage.bold(fee)
+
+    # Memo
+    memoPage = Text("Memo", ui.ICON_SEND, ui.BLUE)
+    memoPage.normal(memo)
+
+    pages = [
+        summaryPage,
+        operatorPage,
+        senderPage,
+        receiverPage,
+        amountPage,
+        feePage,
+        memoPage,
+    ]
+
+    paginated = Paginated(pages)
+    await require_hold_to_confirm(ctx, paginated, ButtonRequestType.SignTx)
+
+
+async def confirm_associate_token(ctx, msg: HederaSignTx):
+    token = format_account(msg.tx.tokenAssociate.tokens[0])
+    account = format_account(msg.tx.tokenAssociate.account)
+    text = Text("Associate token:", ui.ICON_CHECK, ui.GREEN)
+    text.bold(token)
+    text.normal("with account:")
+    text.bold(account)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)

--- a/core/src/apps/hedera/sign_tx.py
+++ b/core/src/apps/hedera/sign_tx.py
@@ -1,0 +1,134 @@
+from trezor.crypto.curve import ed25519
+from trezor.messages import HederaSignTx
+from trezor.messages import HederaSignedTx
+from trezor.strings import format_amount
+
+from apps.common import paths
+from apps.common.keychain import auto_keychain
+
+from .layout import (
+    confirm_account,
+    confirm_associate_token,
+    confirm_create_account,
+    confirm_transfer_hbar,
+    confirm_transfer_token,
+    format_account,
+)
+
+transaction_types = {
+    "CONFIRM": "Confirm Account",
+    "CREATE": "Create Account",
+    "TOKEN": "Token Transfer",
+    "HBAR": "Hbar Transfer",
+    "ASSOCIATE": "Token Associate",
+}
+
+
+def validate_tx(msg: HederaSignTx) -> str | None:
+    if msg.tx is not None:
+        # Create Account
+        if msg.tx.cryptoCreateAccount is not None:
+            # can't be both
+            if msg.tx.cryptoTransfer is not None:
+                return None
+
+            return transaction_types["CREATE"]
+
+        # Confirm Account, Transfer Hbar, Transfer Token
+        if msg.tx.cryptoTransfer is not None:
+            # Hbar transfer
+            if msg.tx.cryptoTransfer.transfers is not None:
+                # but also has token transfers (unsupported)
+                if msg.tx.cryptoTransfer.tokenTransfers is not None:
+                    return None
+
+                # at most two parties (confirm account, hbar transfer)
+                if len(msg.tx.cryptoTransfer.transfers.accountAmounts) > 2:
+                    return None
+
+                # between sender and one other account
+                if len(msg.tx.cryptoTransfer.transfers.accountAmounts) == 2:
+                    return transaction_types["HBAR"]
+
+                # transfer 0 hbar to nobody, with a max fee of 1 tinybar
+                # this fails precheck on hedera in a way that signifies whether or not the account
+                # used as the operator is associated with the key used to sign this transaction
+                if (
+                    len(msg.tx.cryptoTransfer.transfers.accountAmounts) == 1
+                    and msg.tx.cryptoTransfer.transfers.accountAmounts[0].amount == 0
+                    and msg.tx.cryptoTransfer.fee == 1
+                ):
+                    return transaction_types["CONFIRM"]
+
+            # Token Transfer
+            if msg.tx.crytpoTransfer.tokenTransfers is not None:
+                # but also has hbar transfers (unsupported)
+                if msg.tx.cryptoTransfer.transfers is not None:
+                    return None
+
+                # more than one token transfer (unsupported)
+                if len(msg.tx.cryptoTransfer.tokenTransfers) >= 1:
+                    return None
+
+                # transfer token to multiple parties (unsupported)
+                if len(msg.tx.cryptoTransfer.tokenTransfers[0].accountAmounts) > 2:
+                    return None
+
+                return transaction_types["TOKEN"]
+
+        if msg.tx.tokenAssociate is not None:
+            if (
+                msg.tx.tokenAssociate.account is not None
+                and len(msg.tx.tokenAssociate.tokens) == 1
+            ):
+                return transaction_types["ASSOCIATE"]
+
+    return None
+
+
+async def handle_confirm_account(ctx, msg: HederaSignTx):
+    account = format_account(
+        msg.tx.cryptoTransfer.transfers.accountAmounts[0].accountID
+    )
+    await confirm_account(ctx, account)
+
+
+async def handle_create_account(ctx, msg: HederaSignTx):
+    initial_balance = format_amount(msg.tx.cryptoCreateAccount.initialBalance, 8)
+    await confirm_create_account(ctx, initial_balance)
+
+
+async def handle_transfer_hbar(ctx, msg: HederaSignTx):
+    await confirm_transfer_hbar(ctx, msg)
+
+
+async def handle_transfer_token(ctx, msg: HederaSignTx):
+    await confirm_transfer_token(ctx, msg)
+
+
+async def handle_associate_token(ctx, msg: HederaSignTx):
+    await confirm_associate_token(ctx, msg)
+
+
+@auto_keychain(__name__)
+async def sign_tx(ctx, msg: HederaSignTx, keychain):
+    await paths.validate_path(ctx, keychain, msg.address_n)
+
+    node = keychain.derive(msg.address_n)
+    current_tx_type = validate_tx(msg)
+
+    if current_tx_type == transaction_types["CONFIRM"]:
+        await handle_confirm_account(ctx, msg)
+    elif current_tx_type == transaction_types["CREATE"]:
+        await handle_create_account(ctx, msg)
+    elif current_tx_type == transaction_types["HBAR"]:
+        await handle_transfer_hbar(ctx, msg)
+    elif current_tx_type == transaction_types["TOKEN"]:
+        await handle_transfer_token(ctx, msg)
+    elif current_tx_type == transaction_types["ASSOCIATE"]:
+        await handle_associate_token(ctx, msg)
+    else:
+        raise ("Hedera: Transaction not supported")
+
+    signature = ed25519.sign(node.private_key(), msg.tx)
+    return HederaSignedTx(signature=signature)

--- a/core/src/trezor/enums/MessageType.py
+++ b/core/src/trezor/enums/MessageType.py
@@ -104,6 +104,10 @@ if not utils.BITCOIN_ONLY:
     EthereumTypedDataValueAck = 468
     EthereumTypedDataSignature = 469
     EthereumSignTypedHash = 470
+    HederaGetPublicKey = 804
+    HederaSignTx = 805
+    HederaPublicKey = 806
+    HederaSignedTx = 807
     NEMGetAddress = 67
     NEMAddress = 68
     NEMSignTx = 69

--- a/core/src/trezor/enums/__init__.py
+++ b/core/src/trezor/enums/__init__.py
@@ -109,6 +109,10 @@ if TYPE_CHECKING:
         EthereumTypedDataValueAck = 468
         EthereumTypedDataSignature = 469
         EthereumSignTypedHash = 470
+        HederaGetPublicKey = 804
+        HederaSignTx = 805
+        HederaPublicKey = 806
+        HederaSignedTx = 807
         NEMGetAddress = 67
         NEMAddress = 68
         NEMSignTx = 69

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -3023,6 +3023,260 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUnknown"]:
             return isinstance(msg, cls)
 
+    class HederaKey(protobuf.MessageType):
+        ed25519: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            ed25519: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaKey"]:
+            return isinstance(msg, cls)
+
+    class HederaId(protobuf.MessageType):
+        shardNum: "int | None"
+        realmNum: "int | None"
+        tokenNum: "int | None"
+
+        def __init__(
+            self,
+            *,
+            shardNum: "int | None" = None,
+            realmNum: "int | None" = None,
+            tokenNum: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaId"]:
+            return isinstance(msg, cls)
+
+    class HederaTimestamp(protobuf.MessageType):
+        seconds: "int | None"
+        nanos: "int | None"
+
+        def __init__(
+            self,
+            *,
+            seconds: "int | None" = None,
+            nanos: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaTimestamp"]:
+            return isinstance(msg, cls)
+
+    class HederaDuration(protobuf.MessageType):
+        seconds: "int | None"
+
+        def __init__(
+            self,
+            *,
+            seconds: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaDuration"]:
+            return isinstance(msg, cls)
+
+    class HederaTransactionID(protobuf.MessageType):
+        accountID: "HederaId | None"
+
+        def __init__(
+            self,
+            *,
+            accountID: "HederaId | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaTransactionID"]:
+            return isinstance(msg, cls)
+
+    class HederaCryptoCreateTransactionBody(protobuf.MessageType):
+        initialBalance: "int | None"
+
+        def __init__(
+            self,
+            *,
+            initialBalance: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaCryptoCreateTransactionBody"]:
+            return isinstance(msg, cls)
+
+    class HederaAccountAmount(protobuf.MessageType):
+        accountID: "HederaId | None"
+        amount: "int | None"
+
+        def __init__(
+            self,
+            *,
+            accountID: "HederaId | None" = None,
+            amount: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaAccountAmount"]:
+            return isinstance(msg, cls)
+
+    class HederaTransferList(protobuf.MessageType):
+        accountAmounts: "list[HederaAccountAmount]"
+
+        def __init__(
+            self,
+            *,
+            accountAmounts: "list[HederaAccountAmount] | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaTransferList"]:
+            return isinstance(msg, cls)
+
+    class HederaTokenTransferList(protobuf.MessageType):
+        token: "HederaId | None"
+        accountAmounts: "list[HederaAccountAmount]"
+
+        def __init__(
+            self,
+            *,
+            accountAmounts: "list[HederaAccountAmount] | None" = None,
+            token: "HederaId | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaTokenTransferList"]:
+            return isinstance(msg, cls)
+
+    class HederaCryptoTransferTransactionBody(protobuf.MessageType):
+        transfers: "HederaTransferList | None"
+        tokenTransfers: "list[HederaTokenTransferList]"
+
+        def __init__(
+            self,
+            *,
+            tokenTransfers: "list[HederaTokenTransferList] | None" = None,
+            transfers: "HederaTransferList | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaCryptoTransferTransactionBody"]:
+            return isinstance(msg, cls)
+
+    class HederaTokenAssociateBody(protobuf.MessageType):
+        account: "HederaId | None"
+        tokens: "list[HederaId]"
+
+        def __init__(
+            self,
+            *,
+            tokens: "list[HederaId] | None" = None,
+            account: "HederaId | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaTokenAssociateBody"]:
+            return isinstance(msg, cls)
+
+    class HederaTransactionBody(protobuf.MessageType):
+        transactionID: "HederaTransactionID | None"
+        transactionFee: "int | None"
+        memo: "str | None"
+        cryptoCreateAccount: "HederaCryptoCreateTransactionBody | None"
+        cryptoTransfer: "HederaCryptoTransferTransactionBody | None"
+        tokenAssociate: "HederaTokenAssociateBody | None"
+
+        def __init__(
+            self,
+            *,
+            transactionID: "HederaTransactionID | None" = None,
+            transactionFee: "int | None" = None,
+            memo: "str | None" = None,
+            cryptoCreateAccount: "HederaCryptoCreateTransactionBody | None" = None,
+            cryptoTransfer: "HederaCryptoTransferTransactionBody | None" = None,
+            tokenAssociate: "HederaTokenAssociateBody | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaTransactionBody"]:
+            return isinstance(msg, cls)
+
+    class HederaPublicKey(protobuf.MessageType):
+        publicKey: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            publicKey: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaPublicKey"]:
+            return isinstance(msg, cls)
+
+    class HederaGetPublicKey(protobuf.MessageType):
+        address_n: "list[int]"
+        show_display: "bool | None"
+
+        def __init__(
+            self,
+            *,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaGetPublicKey"]:
+            return isinstance(msg, cls)
+
+    class HederaSignedTx(protobuf.MessageType):
+        signature: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            signature: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaSignedTx"]:
+            return isinstance(msg, cls)
+
+    class HederaSignTx(protobuf.MessageType):
+        publicKey: "bytes | None"
+        tx: "HederaTransactionBody | None"
+        decimals: "int | None"
+
+        def __init__(
+            self,
+            *,
+            publicKey: "bytes | None" = None,
+            tx: "HederaTransactionBody | None" = None,
+            decimals: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HederaSignTx"]:
+            return isinstance(msg, cls)
+
     class EthereumGetPublicKey(protobuf.MessageType):
         address_n: "list[int]"
         show_display: "bool | None"

--- a/docs/misc/coins-bip44-paths.md
+++ b/docs/misc/coins-bip44-paths.md
@@ -29,6 +29,7 @@ algorithm, extended to work on other curves.
 | NEM      | ed25519   | `44'/43'/a'`       |             | [5](#NEM)      |
 | Monero   | ed25519   | `44'/128'/a'`      |             |                |
 | Tezos    | ed25519   | `44'/1729'/a'`     |             | [6](#Tezos)    |
+| Hbar     | ed25519   | `44'/3030'/0'/0/a` |             | [7](#Hedera)   |
 
 `c` stands for the [SLIP-44 id] of the currency, when multiple currencies are handled
 by the same code. `a` is an account number, `y` is change address indicator (must be
@@ -83,6 +84,9 @@ sends `44'/60'/0'/0` for getPublicKey.
 
 6. <a name="Tezos"></a> Tezos supports multiple curves, but Trezor currently supports
    ed25519 only.
+
+7. <a name="Hedera"></a> We believe this should be `44'/c'/a'`, because Hedera Hashgraph is
+   account-based. Historically, Hbar tools (MHW) do not use this scheme and instead set `a = 0`, then iterate on the address index `i`. Therefore, for compatibility reasons we use the same scheme.
 
 Sign message paths are validated in the same way as the sign tx paths are.
 

--- a/tools/build_protobuf
+++ b/tools/build_protobuf
@@ -13,6 +13,7 @@ CORE_PROTOBUF_SOURCES="\
     $PROTOB/messages-crypto.proto \
     $PROTOB/messages-debug.proto \
     $PROTOB/messages-eos.proto \
+    $PROTOB/messages-hedera.proto \
     $PROTOB/messages-ethereum.proto \
     $PROTOB/messages-ethereum-eip712.proto \
     $PROTOB/messages-management.proto \


### PR DESCRIPTION
This PR implements the Hedera Hbar signing functionality to Trezor.

The files under `enums` and `messages` are auto-generated from `messages-hedera.proto`. No need to review them, but you can use them as a reference for how the generated Python classes look. (they are basically dataclasses with the described structure)

Brief overview of the overall architecture: Trezor communicates with the host computer by exchanging protobuf messages in a strict request-response scheme. The framework will decode the protobuf message into an instance of the corresponding class, and pass that instance to a registered handler.
The job of the handler is to present the data to the user for review, and when confirmed, produce the result (address in case of `get_pk`, transaction signature in case of `sign_tx`) and return it as another protobuf instance. This instance is then again encoded and sent back to the host.

In a real example, Hedera handlers would need to be registered to handle the appropriate incoming messages: `get_pk(...)` for `HederaGetPublicKey`, `sign_tx(...)` for `HederaSignTx`. Please assume that this registration has happened.

Layout functionality (`layout.py`, bits and pieces elsewhere) is not updated to the current state of the codebase, so the code would currently fail to run. Please proceed as if all calls to the imported layout functions will succeed as written.
(This does not mean that the usages are necessarily correct or reasonable.)

Please approach the example as you would a real-world PR from an external contributor, and do a first-round review, pointing out deficiencies and things to improve for the next iteration.